### PR TITLE
Add an example of using a speculative polyfill in private scope, closes #3

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,9 +178,14 @@
 
     ### Do not automatically prefer native implementations for speculative polyfills
 
-    If a feature is yet to reach the tipping point, using polyfills that squat on the common name for the feature is highly inadvisable, because when the feature is finalised, it might work differently to the polyfill you are using, and your website may break.  If a polyfill author has followed good practice by providing a polyfill with a non-conflicting name, don't undo this good practice by aliasing it to the common name.
+    If a feature is yet to reach the tipping point, using polyfills that squat on the proposed name for the feature is highly inadvisable, because when the feature is finalised, it might work differently to the polyfill you are using, and your website may break.  If a polyfill author has followed good practice for pre-tipping point features by providing a polyfill with a non-conflicting name, don't undo this good practice by aliasing it to the proposed name.
 
-    Instead, use the speculative polyfill as a library, wait until the feature has passed the tipping point, then update your code to use a transparent polyfill that automatically defers to native implementations where they exist.
+    Instead, use the speculative polyfill in private scope or under a custom name, wait until the feature has passed the tipping point, then update your code to use a polyfill that automatically defers to native implementations where they exist.
+
+    <pre class="example">import rafPolyfill from 'request-animation-frame';
+rafPolyfill(function() {
+  ...
+});</pre>
 
     ### Do not serve polyfills that are not required by the user
 


### PR DESCRIPTION
May address the point raised by @bkardell and @domenic in #3.

Despite raf being a widely supported feature at this point, it seems pointless to use a proposed feature since that proposed feature will at some point become a widely supported feature (and might end up different to the current proposal).  So it seemed better to use a feature developers would find more familiar.