### PR TITLE
Remove reference to polyfill.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
 
     ### Use smart distribution
 
-    Choose a platform on which to publish your polyfill from which developers can easily consume it in a way that keeps up to date with changes to the original source.  For example, use a module registry like [npmjs.org](https://npmjs.org/), and consider hosting the polyfill on a reputable service from which it can be directly loaded in the browser.
+    Choose a platform on which to publish your polyfill from which developers can easily consume it in a way that keeps up to date with changes to the original source.  For example, use a module registry and consider hosting the polyfill on a reputable service from which it can be directly loaded in the browser.
 
     ### Don't squat on proposed names in speculative polyfills
 

--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
 
     ### Use smart distribution
 
-    Choose a platform on which to publish your polyfill from which developers can easily consume it in a way that keeps up to date with changes to the original source.  For example, use a module registry like [npmjs.org](https://npmjs.org/), and consider hosting the polyfill on a service from which it can be directly loaded in the browser, such as [cdnjs.com](https://cdnjs.com/) or [polyfill.io](https://polyfill.io/).
+    Choose a platform on which to publish your polyfill from which developers can easily consume it in a way that keeps up to date with changes to the original source.  For example, use a module registry like [npmjs.org](https://npmjs.org/), and consider hosting the polyfill on a reputable service from which it can be directly loaded in the browser.
 
     ### Don't squat on proposed names in speculative polyfills
 


### PR DESCRIPTION
The owner of the polyfill.io domain appears to have changed. The website for the project links to a GitHub repo owned by an individual, but there's no information about governance or any indication that the hosted service is still operated by that individual.  The TAG should no longer link to this and should consider it a security risk.

The finding also links to CDNJS, which could be retained, and does seem to have more transparent governance, but overall it seems worth the TAG not endorsing any one site.